### PR TITLE
Fix fs.readSync usage for Node version 11 and below

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ class Tail extends Readable {
       } else {
         const buff = Buffer.alloc(fs.fstatSync(this.target).size)
 
-        fs.readSync(this.target, buff, { position: 0 })
+        fs.readSync(this.target, buff, 0, buff.length, 0)
 
         data = buff.toString(this.options.encoding)
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "better-tail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-tail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Node.js implementation of UNIX tail command using streams. No dependencies.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "lint": "standard index.js test/index.js",
     "fix-lint": "npm run lint -- --fix",
-    "test": "mocha -b",
-    "preversion": "npm run minify"
+    "test": "mocha -b"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,6 @@ describe('better-tail', function () {
             const data = []
     
             new Tail(target).on('data', (line) => {
-                console.log(line.toString('utf8'))
                 data.push(line)
             }).on('end', () => {
                 expect(data[0]).to.be.instanceof(Buffer, 'Expected data to be an instance of Buffer')
@@ -174,9 +173,7 @@ describe('better-tail', function () {
             const buff = Buffer.alloc(bytes)
             
             // Read file last N bytes
-            fs.readSync(corpus.fd, buff, {
-                position: contentByteLength - bytes
-            })
+            fs.readSync(corpus.fd, buff, 0, buff.length, contentByteLength - bytes)
 
             const data = []
     
@@ -214,9 +211,7 @@ describe('better-tail', function () {
             const buff = Buffer.alloc(contentByteLength - startAtByte)
             
             // Read file from picked byte
-            fs.readSync(corpus.fd, buff, {
-                position: startAtByte
-            })
+            fs.readSync(corpus.fd, buff, 0, buff.length, startAtByte)
 
             const data = []
     
@@ -260,9 +255,7 @@ describe('better-tail', function () {
             const buff = Buffer.allocUnsafe(linesByteLength)
             
             // Read file from last N lines byte length
-            fs.readSync(corpus.fd, buff, {
-                position: contentByteLength - linesByteLength
-            })
+            fs.readSync(corpus.fd, buff, 0, buff.length, contentByteLength - linesByteLength)
 
             const data = []
     
@@ -306,9 +299,7 @@ describe('better-tail', function () {
             const linesByteLength = Buffer.byteLength(contentLines.slice(lines).join('\r\n'))
             const buff = Buffer.allocUnsafe(linesByteLength)
             
-            fs.readSync(corpus.fd, buff, {
-                position: contentByteLength - linesByteLength
-            })
+            fs.readSync(corpus.fd, buff, 0, buff.length, contentByteLength - linesByteLength)
 
             const data = []
     


### PR DESCRIPTION
[As of Node.js documentation](https://nodejs.org/docs/latest-v11.x/api/fs.html#fs_fs_readsync_fd_buffer_offset_length_position), `fs.readSync` method was not available with following signature `fd, buffer, [options]` which was used in code and tests.