### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node: [6, 7, 8, 9]
+        node: [8, 9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
       - run: npm i
+      - run: npm i -D mocha@7
       - run: npm test
   test-from-node-10:
     needs: [lint, test-pre-node-10]


### PR DESCRIPTION
- Drop tests on Node.js 6 and 7 (no stream `_destroy` method support)
- Use mocha v7 for tests on Node.js 8 and 9