### PR TITLE
Add support for customizable retry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,13 @@ new Tail(fs.openSync('./some-file', 'r'))
 
 ### :speech_balloon: Options
 
-Second parameter is an object of following `options`. Those options are equivalent to UNIX `tail` command.
+Second parameter is an object of following `options` (heavily inspired by UNIX `tail` command options):
 
 #### bytes _(default: undefined)_
 
 Number of bytes to tail. Can be prepend with `+` to start tailing from given byte.
+
+> _If this option is set, it supersedes [lines option][lines-option]._
 
 ```js
 // Will return lines in last 42 bytes of target content
@@ -122,9 +124,6 @@ new Tail(target, { bytes: 42 })
 // Will return lines starting from byte 42 until target content end
 new Tail(target, { bytes: '+42' })
 ```
-
-_If this option is set, it supersedes [lines option][lines-option]._
-
 #### follow _(default: false)_
 
 Follow target new content. This option keeps polling target for new content until you stop following it.
@@ -151,6 +150,8 @@ setTimeout(function () {
 
 Number of lines to tail. Can be prepend with `+` to start tailing from given line.
 
+> _This option is superseded by [bytes option][bytes-option]._
+
 ```js
 // Will return last 42 lines of target content
 new Tail(target, { bytes: 42 })
@@ -158,8 +159,6 @@ new Tail(target, { bytes: 42 })
 // Will return lines starting from line 42 until target content end
 new Tail(target, { bytes: '+42' })
 ```
-
-_This option is superseded by [bytes option][bytes-option]._
 
 #### retry _(default: false)_
 
@@ -169,11 +168,28 @@ Keep trying to open target file if it is inaccessible. This option uses [sleepIn
 
 Sleep for approximately N milliseconds between target content next poll.
 
-_This option has no effect if [follow option][follow-option] is set to `false`._
+> _This option has no effect if [follow option][follow-option] is set to `false`._
+
+```js
+// Will poll target new data approximately each 5 seconds
+new Tail(target, { follow: true, sleepInterval: 5000 })
+```
 
 #### encoding _(default: 'utf8')_
 
 Set target’s content encoding.
+
+Supported encodings are [those supported by Node.js][node-encodings]:
+- `utf8`
+- `utf16le`
+- `latin1`
+- `base64`
+- `hex`
+- `ascii`
+- `binary`
+- `ucs2`
+
+[:bulb: Seeking help for testing this option][encoding-tests-help-wanted]
 
 ## :scroll: Methods
 
@@ -309,3 +325,5 @@ Obviously, [Luca Grulla][lucagrulla] for inspiring me to do this.
 [repotags]: https://github.com/g-script/better-tail/tags
 [nicolas-goudry]: https://github.com/nicolas-goudry
 [lucagrulla]: https://github.com/lucagrulla
+[node-encodings]: https://nodejs.org/docs/latest-v14.x/api/buffer.html#buffer_buffers_and_character_encodings
+[encoding-tests-help-wanted]: https://github.com/g-script/better-tail/issues/20

--- a/README.md
+++ b/README.md
@@ -162,7 +162,32 @@ new Tail(target, { bytes: '+42' })
 
 #### retry _(default: false)_
 
-Keep trying to open target file if it is inaccessible. This option uses [sleepInterval option][sleepinterval-option] value to wait between retries.
+If set to true: keep trying to open target file if it is inaccessible.
+
+Can also be an object with following properties:
+- **interval**: wait for given milliseconds between retries
+- **timeout**: abort retrying after given milliseconds
+- **max**: abort retrying after given retries count
+
+> _This option uses [sleepInterval option][sleepinterval-option] value by default to wait between retries._
+
+```js
+// Will retry indefinitly, approximately each second (default value of sleepInterval option), until file is accessible
+new Tail(target, { retry: true })
+
+// Will wait for approximately 5 seconds between retries
+new Tail(target, { retry: { interval: 5000 } })
+
+// Will retry for approximately 5 seconds before aborting
+new Tail(target, { retry: { timeout: 5000 } })
+
+// Will retry 3 times before aborting
+// Note: first try is not counted, so file access will be tried 4 times
+new Tail(target, { retry: { max: 3 } })
+
+// Will retry 5 times or approximately 3 seconds before aborting
+new Tail(target, { retry: { timeout: 3000, max: 5, interval: 5000 } })
+```
 
 #### sleepInterval _(default: 1000)_
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,9 @@ class Tail extends Readable {
    * @param {Number} [options.bytes] Return the last N bytes; or use +N to output starting with byte N; will be ignored if lines options is set
    * @param {Boolean} [options.follow=false] Return appended data as the file grows
    * @param {Number} [options.lines=10] Return the last N lines; or use +N to output starting with line N; set it to zero or a negative value to return all lines
-   * @param {Boolean} [options.retry=false] Keep trying to open a file if it is inaccessible
+   * @param {Boolean|Object} [options.retry=false] Keep trying to open a file if it is inaccessible
+   * @param {Number} [options.retry.timeout] Stop retrying after N milliseconds
+   * @param {Number} [options.retry.max] Retry N times before giving up
    * @param {Number} [options.sleepInterval=1000] With follow option set to true, sleep for approximately N milliseconds between iterations
    * @param {String} [options.encoding=utf8] File characters encoding
    * @emits Tail#error if target is invalid or file doesn’t exists or user lacks permissions on file
@@ -98,6 +100,16 @@ class Tail extends Readable {
     }
   }
 
+  _stopRetry (errMessage) {
+    clearTimeout(this.nextRetryTimeout)
+    clearTimeout(this.abortRetryTimeout)
+
+    this.options.retry = undefined
+
+    this.debug(errMessage)
+    this.destroy(new Error(errMessage))
+  }
+
   /**
     * Check file access
     * @param {Function} cb Callback
@@ -105,7 +117,11 @@ class Tail extends Readable {
     * @returns {void}
     */
   _checkFile (cb) {
-    clearTimeout(this.retryTimeout)
+    // Clear previous nextRetryTimeout
+    clearTimeout(this.nextRetryTimeout)
+
+    // Increment retry count or start it at 0
+    this.retryCount = ++this.retryCount || 0
 
     try {
       if (this.type === 'path') {
@@ -116,14 +132,26 @@ class Tail extends Readable {
         this.debug('Target is available')
       }
 
-      clearTimeout(this.retryTimeout)
-
-      this.retryTimeout = undefined
+      // Clean retry timeouts
+      clearTimeout(this.nextRetryTimeout)
+      clearTimeout(this.abortRetryTimeout)
 
       cb()
     } catch (err) {
       if (this.options.retry) {
-        this.retryTimeout = setTimeout(() => {
+        // Only create abortRetryTimeout once
+        if (this.options.retry.timeout && !this.abortRetryTimeout) {
+          this.abortRetryTimeout = setTimeout(this._stopRetry.bind(this, 'Retry timeout reached'), this.options.retry.timeout)
+        }
+
+        if (this.options.retry.max && this.options.retry.max === this.retryCount) {
+          this._stopRetry('Max retries reached')
+
+          return
+        }
+
+        // Create new nextRetryTimeout
+        this.nextRetryTimeout = setTimeout(() => {
           this.debug('Failed to check target, retrying now…')
 
           return this._checkFile(cb)

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,7 +155,7 @@ class Tail extends Readable {
           this.debug('Failed to check target, retrying now…')
 
           return this._checkFile(cb)
-        }, this.options.sleepInterval)
+        }, this.options.retry.interval || this.options.sleepInterval)
       } else {
         this.debug(`Failed to check target availability: ${err}`)
         this.destroy(err)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,7 +88,19 @@ const validateOptions = (options) => {
   try {
     castedOptions.retry = castBoolean(castedOptions.retry)
   } catch (err) {
-    throw new Error(`Invalid value provided to follow option: ${castedOptions.retry}`)
+    if (castedOptions.retry) {
+      if (castedOptions.retry.timeout && isNaN(castedOptions.retry.timeout)) {
+        throwError('retry.timeout', castedOptions.retry.timeout)
+      }
+
+      if (castedOptions.retry.max && isNaN(castedOptions.retry.max)) {
+        throwError('retry.max', castedOptions.retry.max)
+      }
+    }
+
+    if (!castedOptions.retry.timeout && !castedOptions.retry.max) {
+      throwError('retry', castedOptions.retry)
+    }
   }
 
   if (isNaN(castedOptions.sleepInterval)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,9 +96,13 @@ const validateOptions = (options) => {
       if (castedOptions.retry.max && isNaN(castedOptions.retry.max)) {
         throwError('retry.max', castedOptions.retry.max)
       }
+
+      if (castedOptions.retry.interval && isNaN(castedOptions.retry.interval)) {
+        throwError('retry.interval', castedOptions.retry.interval)
+      }
     }
 
-    if (!castedOptions.retry.timeout && !castedOptions.retry.max) {
+    if (!castedOptions.retry.timeout && !castedOptions.retry.max && !castedOptions.retry.interval) {
       throwError('retry', castedOptions.retry)
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,6 +46,15 @@ const validateEncoding = (encoding) => {
 }
 
 /**
+ * Throw option validation error
+ * @param {String} option Option that throws
+ * @param {any} original Option original value
+ */
+const throwError = (option, original) => {
+  throw new Error(`Invalid value provided to ${option} option: ${original}`)
+}
+
+/**
  * Validate options object passed to constructor
  * @param {Object} options Object of options to validate
  * @throws if an option is invalid
@@ -63,17 +72,17 @@ const validateOptions = (options) => {
 
   // bytes option has no default, we need to make sure it is present before checking it
   if (castedOptions.bytes && isNaN(castedOptions.bytes)) {
-    throw new Error(`Invalid value provided to bytes option: ${castedOptions.bytes}`)
+    throwError('bytes', castedOptions.bytes)
   }
 
   try {
     castedOptions.follow = castBoolean(castedOptions.follow)
   } catch (err) {
-    throw new Error(`Invalid value provided to follow option: ${castedOptions.follow}`)
+    throwError('follow', castedOptions.follow)
   }
 
   if (isNaN(castedOptions.lines)) {
-    throw new Error(`Invalid value provided to bytes option: ${castedOptions.lines}`)
+    throwError('lines', castedOptions.lines)
   }
 
   try {
@@ -83,13 +92,13 @@ const validateOptions = (options) => {
   }
 
   if (isNaN(castedOptions.sleepInterval)) {
-    throw new Error(`Invalid value provided to sleepInterval option: ${castedOptions.sleepInterval}`)
+    throwError('sleepInterval', castedOptions.sleepInterval)
   }
 
   try {
     validateEncoding(castedOptions.encoding)
   } catch (err) {
-    throw new Error(`Invalid value provided to encoding: ${castedOptions.encoding}`)
+    throwError('encoding', castedOptions.encoding)
   }
 
   return castedOptions

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint",
-      "pre-push": "npm run test"
+      "pre-commit": "npm run lint"
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -416,13 +416,13 @@ describe('better-tail', function () {
 
         it('should retry until file is accessible', function (done) {
             this.timeout(10000)
-            this.slow(5500)
+            this.slow(11000)
 
             const data = []
 
             setTimeout(() => {
                 fs.writeFileSync(filePathToWait, corpus.expectations.noOptions, { encoding: 'utf8' })
-            })
+            }, 5000)
 
             new Tail(filePathToWait, {
                 retry: true

--- a/test/index.js
+++ b/test/index.js
@@ -477,6 +477,27 @@ describe('better-tail', function () {
             })
         })
 
+        it('should retry each 2 seconds', function (done) {
+            this.timeout(10000)
+            this.slow(11000)
+
+            const data = []
+            const fileWriteTimeout = setTimeout(() => {
+                fs.writeFileSync(filePathToWait, corpus.expectations.noOptions, { encoding: 'utf8' })
+            }, 4500)
+
+            new Tail(filePathToWait, {
+                retry: {
+                    interval: 2000
+                }
+            }).on('end', () => {
+                done()
+            })
+            .on('error', (err) => {
+                done(err)
+            })
+        })
+
         it('should fail with invalid value', function (done) {
             new Tail(corpus.path, {
                 retry: () => {}


### PR DESCRIPTION
Closes #4 

All features listed on linked issue are now supported.

Another option `interval` has been added to allow customizing interval between retries rather than using `sleepInterval` value. If it is not set, time between retries keeps defaulting to `sleepInterval` value.